### PR TITLE
Configure container boot order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
         volumes:
             - ./secrets/tor:/var/lib/tor
             - ./tor/torrc:/etc/tor/torrc
+        depends_on:
+            - api
 
 volumes:
     mysqldata:


### PR DESCRIPTION
`tor` must be started after `api` to resolve name correctly