### PR TITLE
Show chatroom information on `GET /message/:roomId`

### DIFF
--- a/api/controller/message.go
+++ b/api/controller/message.go
@@ -181,8 +181,11 @@ func ShowMessages(c *gin.Context) {
 	messages := fromDBMessages(rawMessages)
 
 	rawRoom, err := db.GetRoom(uint(chatroomId))
-	if err != nil {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "room not found"})
+		return
+	} else if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": error.Error})
 		return
 	}
 	room := fromDBRoom(rawRoom)

--- a/api/db/query.go
+++ b/api/db/query.go
@@ -154,8 +154,7 @@ func CreateRoom(userIds []uint) (Chatroom, error) {
 
 func GetRoom(roomId uint) (Chatroom, error) {
 	room := Chatroom{}
-	room.ID = roomId
-	err := database.Model(&Chatroom{}).Find(&room).Error
+	err := database.First(&room, roomId).Error
 	if err != nil {
 		return Chatroom{}, err
 	}


### PR DESCRIPTION
#35 

It should be included in the response, but I was forgetting to put it.

This PR adds them and fixes some errors-handling.