### PR TITLE
Run Tor service as root inside Docker container

### DIFF
--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -2,8 +2,4 @@ FROM alpine:latest
 
 RUN apk update && apk add tor curl
 
-RUN chown -R tor /etc/tor /var/lib/tor
-RUN chmod -R 700 /var/lib/tor
-
-USER tor
 CMD tor -f /etc/tor/torrc


### PR DESCRIPTION
#38 

Previously, the Tor service was run by a `tor` user in the container.

It had some troubles, but those can be solved by running as a root.

Although it may have problems, it is preferred that "works" than "perfect".